### PR TITLE
Add Expo React Native scaffold with Firebase

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,26 @@
+import React, { useEffect } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import HomeScreen from './screens/HomeScreen';
+import GameSetupScreen from './screens/GameSetupScreen';
+import LiveGameScreen from './screens/LiveGameScreen';
+import { signIn } from './config/firebase';
+
+const Stack = createStackNavigator();
+
+export default function App() {
+  useEffect(() => {
+    // Sign in anonymously for demo purposes
+    signIn().catch(err => console.log('Auth Error', err));
+  }, []);
+
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Home">
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="GameSetup" component={GameSetupScreen} options={{ title: 'Game Setup' }} />
+        <Stack.Screen name="LiveGame" component={LiveGameScreen} options={{ title: 'Live Game' }} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # GolfApp
+
+This project contains a React Native application scaffold created with Expo. It demonstrates a basic flow for a golf side game and betting app, including:
+
+- **Home Screen** – choose a game type (Skins, Wolf, Stroke Play)
+- **Game Setup Screen** – add players and select side bets
+- **Live Game Screen** – display scores and bet summaries in real time
+
+Firebase is initialized for authentication and real-time database usage. Authentication uses anonymous sign in for testing purposes. Game calculations are placeholders to allow iteration on the user interface before integrating a full game engine.
+
+Run the app with `npm start` (Expo CLI required).

--- a/config/firebase.js
+++ b/config/firebase.js
@@ -1,0 +1,20 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth, signInAnonymously } from 'firebase/auth';
+import { getDatabase } from 'firebase/database';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  databaseURL: 'YOUR_DB_URL',
+  projectId: 'YOUR_PROJECT_ID',
+  storageBucket: 'YOUR_STORAGE_BUCKET',
+  messagingSenderId: 'YOUR_SENDER_ID',
+  appId: 'YOUR_APP_ID',
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const db = getDatabase(app);
+
+export const signIn = () => signInAnonymously(auth);
+export default app;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "GolfApp",
+  "version": "0.1.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^48.0.0",
+    "react": "18.2.0",
+    "react-native": "0.71.0",
+    "firebase": "^9.23.0",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/stack": "^6.3.16",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-paper": "^5.0.0"
+  }
+}

--- a/screens/GameSetupScreen.js
+++ b/screens/GameSetupScreen.js
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Button, Text, TextInput } from 'react-native-paper';
+
+export default function GameSetupScreen({ route, navigation }) {
+  const { gameType } = route.params;
+  const [players, setPlayers] = useState(['Alice', 'Bob']);
+  const [bet, setBet] = useState('');
+
+  const startGame = () => {
+    navigation.navigate('LiveGame', { gameType, players, bet });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text variant="headlineSmall" style={styles.title}>{gameType} Setup</Text>
+      <Text>Players:</Text>
+      {players.map(p => (
+        <Text key={p}>{p}</Text>
+      ))}
+      <TextInput
+        label="Side Bet ($)"
+        value={bet}
+        onChangeText={setBet}
+        keyboardType="numeric"
+        style={styles.input}
+      />
+      <Button mode="contained" onPress={startGame} style={styles.button}>
+        Start Game
+      </Button>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  title: {
+    marginBottom: 16,
+  },
+  input: {
+    marginVertical: 8,
+  },
+  button: {
+    marginTop: 24,
+  },
+});

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Button, Text } from 'react-native-paper';
+
+const GAME_TYPES = ['Skins', 'Wolf', 'Stroke Play'];
+
+export default function HomeScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Text variant="headlineMedium" style={styles.title}>Choose Game Type</Text>
+      {GAME_TYPES.map(type => (
+        <Button
+          key={type}
+          mode="contained"
+          style={styles.button}
+          onPress={() => navigation.navigate('GameSetup', { gameType: type })}
+        >
+          {type}
+        </Button>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    marginBottom: 24,
+  },
+  button: {
+    marginVertical: 8,
+    width: '80%',
+  },
+});

--- a/screens/LiveGameScreen.js
+++ b/screens/LiveGameScreen.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { View, FlatList, StyleSheet } from 'react-native';
+import { Text } from 'react-native-paper';
+
+export default function LiveGameScreen({ route }) {
+  const { gameType, players, bet } = route.params;
+  const scores = players.map(p => ({ player: p, score: 0 }));
+
+  return (
+    <View style={styles.container}>
+      <Text variant="headlineSmall" style={styles.title}>{gameType} Live</Text>
+      <Text>Side Bet: ${bet || '0'}</Text>
+      <FlatList
+        data={scores}
+        keyExtractor={item => item.player}
+        renderItem={({ item }) => (
+          <View style={styles.row}>
+            <Text>{item.player}</Text>
+            <Text>{item.score}</Text>
+          </View>
+        )}
+        style={styles.list}
+      />
+      <Text style={styles.note}>* Scores and bet calculations are placeholders.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  title: {
+    marginBottom: 16,
+  },
+  list: {
+    marginTop: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderColor: '#ccc',
+  },
+  note: {
+    marginTop: 24,
+    fontStyle: 'italic',
+  },
+});


### PR DESCRIPTION
## Summary
- create minimal Expo project with package.json
- initialize Firebase with anonymous sign-in helper
- set up navigation between Home, GameSetup, and LiveGame screens
- implement placeholder UI for picking games and tracking scores
- update README with project overview

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684390ced9d8832a88c04ce97826b0cd